### PR TITLE
Fix: Removed erroneous non-breaking space

### DIFF
--- a/dist/Tuio.js
+++ b/dist/Tuio.js
@@ -287,7 +287,7 @@ Tuio.Point = Tuio.Model.extend({
 
     initialize: function(params) {
         this.xPos = params.xp || 0;
-        this.yPos = params.yp || 0;
+        this.yPos = params.yp || 0;
         this.currentTime = Tuio.Time.fromTime(params.ttime || Tuio.Time.getSessionTime());
         this.startTime = Tuio.Time.fromTime(this.currentTime);
     },


### PR DESCRIPTION
• Tuio.js had a non-breaking space (U+00A0) where there surely should've been one.  Removed.
    » The error thrown by Firefox 33.0's JS engine was “SyntaxError: missing ; before statement — Tuio.js:290”.
    » Tuio.min.js is fine— all the spaces, non-breaking or normal, are already stripped out.
